### PR TITLE
Add flag to add jira code to commit message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Because it's a pain to always write the co-authors following the [correct format
 ## mommit add
 
 You have three ways to add an author to your mommit:
+
 1. `mommit add` - manually add using the prompt
 1. `mommit add -l` - select from a list of authors from git log
 1. `mommit add -s` - search for a single author from git log
@@ -32,3 +33,7 @@ If you want to remove an author from your list, just call `mommit remove` and se
 ## mommit list
 
 If you want to see which users are already added, just call `mommit list` to see which users are stored inside mommit.
+
+## add jira code
+
+If you want to add the JIRA code to your commit in the format `[<ticket-number>] <commit-message>`, create a branch starting with the ticket number and use the `-j` flag. Example: using the command `mommit -j` on the branch `MS-101-branch-description` will create a commit on the format `[MS-101] Testing`.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ If you want to see which users are already added, just call `mommit list` to see
 ## add jira code
 
 If you want to add the JIRA code to your commit in the format `[<ticket-number>] <commit-message>`, create a branch starting with the ticket number and use the `-j` flag. Example: using the command `mommit -j` on the branch `MS-101-branch-description` will create a commit on the format `[MS-101] Testing`.
+
+TODO: add support to `-m` with `-j`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,5 @@ If you want to see which users are already added, just call `mommit list` to see
 
 ## add jira code
 
-If you want to add the JIRA code to your commit in the format `[<ticket-number>] <commit-message>`, create a branch starting with the ticket number and use the `-j` flag. Example: using the command `mommit -j` on the branch `MS-101-branch-description` will create a commit on the format `[MS-101] Testing`.
-
-TODO: add support to `-m` with `-j`
+If you want to add the JIRA code to your commit in the format `[<ticket-number>] <commit-message>`, create a branch starting with the ticket number and use the `-j` flag.  
+Example: using the command `mommit -jam "Testing"` on the branch `MS-101-branch-description` will `git add` the files and create a commit on the format `[MS-101] Testing`.

--- a/commands/commit.js
+++ b/commands/commit.js
@@ -2,14 +2,30 @@ const inquirer = require("inquirer"),
   { exec } = require("child_process"),
   authors = require("./authors");
 
+async function getJiraCode() {
+  let promise = new Promise((resolve, reject) => {
+    exec("git rev-parse --abbrev-ref HEAD", (stderr, stdout) => {
+      let currentJiraCode = "";
+      const branch = stdout.trim().split("-").splice(0, 2);
+      if (branch[0] === branch[0].toUpperCase() && !isNaN(branch[1])) {
+        currentJiraCode = branch.join("-");
+      }
+      resolve(stdout ? currentJiraCode : stderr);
+    });
+  });
+  return promise.then((jiraCode) => jiraCode);
+}
+
 module.exports = async function (opt) {
   const authorList = await authors.get();
   const prompts = [];
   if (opt.j) {
+    let branch = await getJiraCode();
     prompts.push({
       type: "input",
-      message: "Branch:",
+      message: "JIRA code:",
       name: "branch",
+      default: branch,
     });
   }
   if (!opt.message) {

--- a/commands/commit.js
+++ b/commands/commit.js
@@ -19,7 +19,7 @@ async function getJiraCode() {
 module.exports = async function (opt) {
   const authorList = await authors.get();
   const prompts = [];
-  if (opt.j) {
+  if (opt.jira) {
     let branch = await getJiraCode();
     prompts.push({
       type: "input",
@@ -29,6 +29,7 @@ module.exports = async function (opt) {
     });
   }
   if (!opt.message) {
+    console.log("! opt msg");
     prompts.push({
       type: "input",
       message: "Commit message:",

--- a/commands/commit.js
+++ b/commands/commit.js
@@ -25,7 +25,7 @@ module.exports = async function (opt) {
             type: 'input',
             message: 'JIRA code:',
             name: 'branch',
-            default: branch,
+            default: branch
         });
     }
     if (!opt.message) {
@@ -34,21 +34,19 @@ module.exports = async function (opt) {
             message: 'Commit message:',
             name: 'commit',
             validate: function (answer) {
-                return answer.trim() === ''
-                    ? 'You should write a message for your commit'
-                    : true;
-            },
+                return answer.trim() === '' ? 'You should write a message for your commit' : true;
+            }
         });
     }
     prompts.push({
         type: 'checkbox',
         message: 'Select authors:',
         name: 'authors',
-        choices: authorList.map((author) => {
+        choices: authorList.map(author => {
             return {
                 name: author.name,
                 value: author,
-                checked: author.default,
+                checked: author.default
             };
         }),
         validate: function (answer) {
@@ -56,7 +54,7 @@ module.exports = async function (opt) {
                 return 'You must choose at least one author.';
             }
             return true;
-        },
+        }
     });
     const answers = await inquirer.prompt(prompts);
     await authors.default(answers.authors);
@@ -64,12 +62,10 @@ module.exports = async function (opt) {
     let command = ['git commit'],
         message = answers.commit || opt.message,
         branch = answers.branch ? `[${answers.branch}] ` : ``,
-        formattedAuthors = answers.authors
-            .map((author) => `Co-authored-by: ${author.name} <${author.email}>`)
-            .join('\\n');
+        formattedAuthors = answers.authors.map(author => `Co-authored-by: ${author.name} <${author.email}>`).join('\\n');
 
     if (Array.isArray(message)) {
-        message = message.map((m) => `${m}`).join('\\n');
+        message = message.map(m => `${m}`).join('\\n');
     }
 
     if (opt.all) {

--- a/commands/commit.js
+++ b/commands/commit.js
@@ -1,84 +1,83 @@
-const inquirer = require("inquirer"),
-  { exec } = require("child_process"),
-  authors = require("./authors");
+const inquirer = require('inquirer'),
+    { exec } = require('child_process'),
+    authors = require('./authors');
 
 async function getJiraCode() {
-  let promise = new Promise((resolve, reject) => {
-    exec("git rev-parse --abbrev-ref HEAD", (stderr, stdout) => {
-      let currentJiraCode = "";
-      const branch = stdout.trim().split("-").splice(0, 2);
-      if (branch[0] === branch[0].toUpperCase() && !isNaN(branch[1])) {
-        currentJiraCode = branch.join("-");
-      }
-      resolve(stdout ? currentJiraCode : stderr);
+    let promise = new Promise((resolve, reject) => {
+        exec('git rev-parse --abbrev-ref HEAD', (stderr, stdout) => {
+            let currentJiraCode = '';
+            const branch = stdout.trim().split('-').splice(0, 2);
+            if (branch[0] === branch[0].toUpperCase() && !isNaN(branch[1])) {
+                currentJiraCode = branch.join('-');
+            }
+            resolve(stdout ? currentJiraCode : stderr);
+        });
     });
-  });
-  return promise.then((jiraCode) => jiraCode);
+    return promise.then((jiraCode) => jiraCode);
 }
 
 module.exports = async function (opt) {
-  const authorList = await authors.get();
-  const prompts = [];
-  if (opt.jira) {
-    let branch = await getJiraCode();
+    const authorList = await authors.get();
+    const prompts = [];
+    if (opt.jira) {
+        let branch = await getJiraCode();
+        prompts.push({
+            type: 'input',
+            message: 'JIRA code:',
+            name: 'branch',
+            default: branch,
+        });
+    }
+    if (!opt.message) {
+        prompts.push({
+            type: 'input',
+            message: 'Commit message:',
+            name: 'commit',
+            validate: function (answer) {
+                return answer.trim() === ''
+                    ? 'You should write a message for your commit'
+                    : true;
+            },
+        });
+    }
     prompts.push({
-      type: "input",
-      message: "JIRA code:",
-      name: "branch",
-      default: branch,
+        type: 'checkbox',
+        message: 'Select authors:',
+        name: 'authors',
+        choices: authorList.map((author) => {
+            return {
+                name: author.name,
+                value: author,
+                checked: author.default,
+            };
+        }),
+        validate: function (answer) {
+            if (answer.length < 1) {
+                return 'You must choose at least one author.';
+            }
+            return true;
+        },
     });
-  }
-  if (!opt.message) {
-    console.log("! opt msg");
-    prompts.push({
-      type: "input",
-      message: "Commit message:",
-      name: "commit",
-      validate: function (answer) {
-        return answer.trim() === ""
-          ? "You should write a message for your commit"
-          : true;
-      },
+    const answers = await inquirer.prompt(prompts);
+    await authors.default(answers.authors);
+
+    let command = ['git commit'],
+        message = answers.commit || opt.message,
+        branch = answers.branch ? `[${answers.branch}] ` : ``,
+        formattedAuthors = answers.authors
+            .map((author) => `Co-authored-by: ${author.name} <${author.email}>`)
+            .join('\\n');
+
+    if (Array.isArray(message)) {
+        message = message.map((m) => `${m}`).join('\\n');
+    }
+
+    if (opt.all) {
+        command.push('-a');
+    }
+    command.push(`-m$'${branch}${message}\\n\\n${formattedAuthors}'`);
+
+    exec(command.join(' '), (err, stdout, stderr) => {
+        console.log(`${stdout}`);
     });
-  }
-  prompts.push({
-    type: "checkbox",
-    message: "Select authors:",
-    name: "authors",
-    choices: authorList.map((author) => {
-      return {
-        name: author.name,
-        value: author,
-        checked: author.default,
-      };
-    }),
-    validate: function (answer) {
-      if (answer.length < 1) {
-        return "You must choose at least one author.";
-      }
-      return true;
-    },
-  });
-  const answers = await inquirer.prompt(prompts);
-  await authors.default(answers.authors);
-
-  let command = ["git commit"],
-    message = answers.commit || opt.message,
-    branch = answers.branch ? `[${answers.branch}] ` : ``,
-    formattedAuthors = answers.authors
-      .map((author) => `Co-authored-by: ${author.name} <${author.email}>`)
-      .join("\\n");
-
-  if (Array.isArray(message)) {
-    message = message.map((m) => `${m}`).join("\\n");
-  }
-
-  if (opt.all) {
-    command.push("-a");
-  }
-  command.push(`-m$'${branch}${message}\\n\\n${formattedAuthors}'`);
-
-  exec(command.join(" "), (err, stdout, stderr) => {
-    console.log(`${stdout}`);
-  });
 };

--- a/commands/commit.js
+++ b/commands/commit.js
@@ -1,55 +1,67 @@
-const inquirer = require('inquirer'),
-    { exec } = require('child_process'),
-    authors = require('./authors');
+const inquirer = require("inquirer"),
+  { exec } = require("child_process"),
+  authors = require("./authors");
 
-module.exports = async function(opt) {
-    const authorList = await authors.get();
-    const prompts = [];
-    if (!opt.message) {
-        prompts.push({
-            type: 'input',
-            message: 'Commit message:',
-            name: 'commit',
-            validate: function(answer) {
-                return answer.trim() === ''? 'You should write a message for your commit' : true;
-            }
-        })
-    }
+module.exports = async function (opt) {
+  const authorList = await authors.get();
+  const prompts = [];
+  if (opt.j) {
     prompts.push({
-        type: 'checkbox',
-        message: 'Select authors:',
-        name: 'authors',
-        choices: authorList.map(author => {
-            return {
-                name: author.name,
-                value: author,
-                checked: author.default
-            };
-        }),
-        validate: function(answer) {
-            if (answer.length < 1) {
-                return 'You must choose at least one author.';
-            }
-            return true;
-        }
+      type: "input",
+      message: "Branch:",
+      name: "branch",
     });
-    const answers = await inquirer.prompt(prompts);
-    await authors.default(answers.authors);
-
-    let command = ['git commit'],
-        message = answers.commit || opt.message,
-        formattedAuthors = answers.authors.map(author => `Co-authored-by: ${author.name} <${author.email}>`).join('\\n');
-
-    if (Array.isArray(message)) {
-        message = message.map(m => `${m}`).join('\\n');
-    }
-
-    if (opt.all) {
-        command.push('-a');
-    }
-    command.push(`-m$'${message}\\n\\n${formattedAuthors}'`);
-
-    exec(command.join(' '), (err, stdout, stderr) => {
-        console.log(`${stdout}`);
+  }
+  if (!opt.message) {
+    prompts.push({
+      type: "input",
+      message: "Commit message:",
+      name: "commit",
+      validate: function (answer) {
+        return answer.trim() === ""
+          ? "You should write a message for your commit"
+          : true;
+      },
     });
+  }
+  prompts.push({
+    type: "checkbox",
+    message: "Select authors:",
+    name: "authors",
+    choices: authorList.map((author) => {
+      return {
+        name: author.name,
+        value: author,
+        checked: author.default,
+      };
+    }),
+    validate: function (answer) {
+      if (answer.length < 1) {
+        return "You must choose at least one author.";
+      }
+      return true;
+    },
+  });
+  const answers = await inquirer.prompt(prompts);
+  await authors.default(answers.authors);
+
+  let command = ["git commit"],
+    message = answers.commit || opt.message,
+    branch = answers.branch ? `[${answers.branch}] ` : ``,
+    formattedAuthors = answers.authors
+      .map((author) => `Co-authored-by: ${author.name} <${author.email}>`)
+      .join("\\n");
+
+  if (Array.isArray(message)) {
+    message = message.map((m) => `${m}`).join("\\n");
+  }
+
+  if (opt.all) {
+    command.push("-a");
+  }
+  command.push(`-m$'${branch}${message}\\n\\n${formattedAuthors}'`);
+
+  exec(command.join(" "), (err, stdout, stderr) => {
+    console.log(`${stdout}`);
+  });
 };

--- a/mommit.js
+++ b/mommit.js
@@ -1,38 +1,54 @@
 #!/usr/bin/env node
 
-const commit = require('./commands/commit'),
-    authors = require('./commands/authors');
+const commit = require("./commands/commit"),
+  authors = require("./commands/authors");
 
-require('yargs')
-    .scriptName('mommit')
-    .usage('$0 [args] or $0 <cmd>')
-    .command('add', 'add a new commiter', yargs => {
-        return yargs
-            .option('l', {
-                alias: 'from-git-log',
-                describe: 'Add users from git log',
-                type: 'boolean'
-            })
-            .option('s', {
-                alias: 'search-git-log',
-                describe: 'Search and add a single user from git log',
-                type: 'boolean'
-            })
-    }, authors.add)
-    .command('remove', 'remove a commiter', authors.remove)
-    .command('list', 'list all commiters', authors.list)
-    .command('$0', 'Commit with co-authors', yargs => {
-        return yargs
-            .option('m', {
-                alias: 'message',
-                describe: 'Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated as separate paragraphs.',
-                type: 'string',
-            })
-            .option('a', {
-                alias: 'all',
-                describe: 'Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.',
-                type: 'boolean',
-            })
-    }, commit)
-    .help()
-    .argv;
+require("yargs")
+  .scriptName("mommit")
+  .usage("$0 [args] or $0 <cmd>")
+  .command(
+    "add",
+    "add a new commiter",
+    (yargs) => {
+      return yargs
+        .option("l", {
+          alias: "from-git-log",
+          describe: "Add users from git log",
+          type: "boolean",
+        })
+        .option("s", {
+          alias: "search-git-log",
+          describe: "Search and add a single user from git log",
+          type: "boolean",
+        });
+    },
+    authors.add
+  )
+  .command("remove", "remove a commiter", authors.remove)
+  .command("list", "list all commiters", authors.list)
+  .command(
+    "$0",
+    "Commit with co-authors",
+    (yargs) => {
+      return yargs
+        .option("m", {
+          alias: "message",
+          describe:
+            "Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated as separate paragraphs.",
+          type: "string",
+        })
+        .option("a", {
+          alias: "all",
+          describe:
+            "Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.",
+          type: "boolean",
+        })
+        .option("j", {
+          alias: "jira",
+          describe: "Add JIRA code.",
+          type: "boolean",
+        });
+    },
+    commit
+  )
+  .help().argv;

--- a/mommit.js
+++ b/mommit.js
@@ -6,49 +6,38 @@ const commit = require('./commands/commit'),
 require('yargs')
     .scriptName('mommit')
     .usage('$0 [args] or $0 <cmd>')
-    .command(
-        'add',
-        'add a new commiter',
-        (yargs) => {
-            return yargs
-                .option('l', {
-                    alias: 'from-git-log',
-                    describe: 'Add users from git log',
-                    type: 'boolean',
-                })
-                .option('s', {
-                    alias: 'search-git-log',
-                    describe: 'Search and add a single user from git log',
-                    type: 'boolean',
-                });
-        },
-        authors.add
-    )
+    .command('add', 'add a new commiter', yargs => {
+        return yargs
+            .option('l', {
+                alias: 'from-git-log',
+                describe: 'Add users from git log',
+                type: 'boolean'
+            })
+            .option('s', {
+                alias: 'search-git-log',
+                describe: 'Search and add a single user from git log',
+                type: 'boolean'
+            })
+    }, authors.add)
     .command('remove', 'remove a commiter', authors.remove)
     .command('list', 'list all commiters', authors.list)
-    .command(
-        '$0',
-        'Commit with co-authors',
-        (yargs) => {
-            return yargs
-                .option('m', {
-                    alias: 'message',
-                    describe:
-                        'Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated as separate paragraphs.',
-                    type: 'string',
-                })
-                .option('a', {
-                    alias: 'all',
-                    describe:
-                        'Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.',
-                    type: 'boolean',
-                })
-                .option('j', {
-                    alias: 'jira',
-                    describe: 'Add JIRA code.',
-                    type: 'boolean',
-                });
-        },
-        commit
-    )
-    .help().argv;
+    .command('$0', 'Commit with co-authors', yargs => {
+        return yargs
+            .option('m', {
+                alias: 'message',
+                describe: 'Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated as separate paragraphs.',
+                type: 'string',
+            })
+            .option('a', {
+                alias: 'all',
+                describe: 'Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.',
+                type: 'boolean',
+            })
+            .option('j', {
+                alias: 'jira',
+                describe: 'Add JIRA code.',
+                type: 'boolean',
+            })
+    }, commit)
+    .help()
+    .argv;

--- a/mommit.js
+++ b/mommit.js
@@ -1,54 +1,54 @@
 #!/usr/bin/env node
 
-const commit = require("./commands/commit"),
-  authors = require("./commands/authors");
+const commit = require('./commands/commit'),
+    authors = require('./commands/authors');
 
-require("yargs")
-  .scriptName("mommit")
-  .usage("$0 [args] or $0 <cmd>")
-  .command(
-    "add",
-    "add a new commiter",
-    (yargs) => {
-      return yargs
-        .option("l", {
-          alias: "from-git-log",
-          describe: "Add users from git log",
-          type: "boolean",
-        })
-        .option("s", {
-          alias: "search-git-log",
-          describe: "Search and add a single user from git log",
-          type: "boolean",
-        });
-    },
-    authors.add
-  )
-  .command("remove", "remove a commiter", authors.remove)
-  .command("list", "list all commiters", authors.list)
-  .command(
-    "$0",
-    "Commit with co-authors",
-    (yargs) => {
-      return yargs
-        .option("m", {
-          alias: "message",
-          describe:
-            "Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated as separate paragraphs.",
-          type: "string",
-        })
-        .option("a", {
-          alias: "all",
-          describe:
-            "Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.",
-          type: "boolean",
-        })
-        .option("j", {
-          alias: "jira",
-          describe: "Add JIRA code.",
-          type: "boolean",
-        });
-    },
-    commit
-  )
-  .help().argv;
+require('yargs')
+    .scriptName('mommit')
+    .usage('$0 [args] or $0 <cmd>')
+    .command(
+        'add',
+        'add a new commiter',
+        (yargs) => {
+            return yargs
+                .option('l', {
+                    alias: 'from-git-log',
+                    describe: 'Add users from git log',
+                    type: 'boolean',
+                })
+                .option('s', {
+                    alias: 'search-git-log',
+                    describe: 'Search and add a single user from git log',
+                    type: 'boolean',
+                });
+        },
+        authors.add
+    )
+    .command('remove', 'remove a commiter', authors.remove)
+    .command('list', 'list all commiters', authors.list)
+    .command(
+        '$0',
+        'Commit with co-authors',
+        (yargs) => {
+            return yargs
+                .option('m', {
+                    alias: 'message',
+                    describe:
+                        'Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated as separate paragraphs.',
+                    type: 'string',
+                })
+                .option('a', {
+                    alias: 'all',
+                    describe:
+                        'Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.',
+                    type: 'boolean',
+                })
+                .option('j', {
+                    alias: 'jira',
+                    describe: 'Add JIRA code.',
+                    type: 'boolean',
+                });
+        },
+        commit
+    )
+    .help().argv;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mommit",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Added a new flag `-j` to automatically add the JIRA ticket number to the commit message

Example: using the command `mommit -jam "Testing"` on the branch `MS-101-branch-description` will `git add` the files and create a commit on the format `[MS-101] Testing`.